### PR TITLE
Restotre AndroisManifest file name when build fail

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -162,11 +162,20 @@ String placeholder = "<!--Placeholder-->"
     preBuild.dependsOn trTask
 }
 
-def renameManifest = tasks.register("renameManifest") {
-    ant.move(file: 'src/main/AndroidManifest.xml', tofile:'src/main/AndroidManifest_original.xml')
+def renameManifestTask = tasks.register("renameManifest") {
+    doLast {
+        if (project.gradle.taskGraph.hasTask(preBuild)) {
+            ant.move(file: 'src/main/AndroidManifest.xml', tofile: 'src/main/AndroidManifest_original.xml')
+        }
+    }
 }
 preBuild.dependsOn renameManifest
 
+gradle.buildFinished {
+    if (gradle.buildResult.failure) {
+        ant.move(file: 'src/main/AndroidManifest_original.xml', tofile: 'src/main/AndroidManifest.xml')
+    }
+}
 
 def generateWebViewActivities = tasks.register( "extendAndroidManifest", Copy ) {
     from 'src/main/AndroidManifest_original.xml'


### PR DESCRIPTION
This commit modifies the build.gradle file to address the issue where the AndroidManifest.xml file was being renamed even if the Gradle build was successful. The changes ensure that the renaming of the AndroidManifest.xml file only occurs when the build fails.

- Updated the 'renameManifest' task to check if the 'preBuild' task is scheduled to run before renaming the AndroidManifest.xml file.
- Added a 'buildFinished' block to restore the original AndroidManifest.xml file if the build result indicates a failure.

These changes provide a more consistent behavior where the AndroidManifest.xml file is renamed only in case of build failures, reducing unnecessary renaming in subsequent builds.